### PR TITLE
Support 'Speedport W724V Type C - Firmware 09011603.00.009'

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Koutheir Attouchi
+Original work Copyright (c) 2015 Koutheir Attouchi
+Modified work Copyright (c) 2015 Moritz Maxeiner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/device_password.conf
+++ b/device_password.conf
@@ -2,31 +2,15 @@
 # Configuration file for speedport-w724v-external-ip-address.
 #
 # This file holds the password for the SpeedPort W724V router.
-# The password is required to retreive the current external IPv4 address of
-# the router.
-#
-# However, for security reasons, the device password should not be stored in
-# plain text, so to specify the password:
-# 1. Set the PASSWORD_PLAIN variable to your password in plain text in this
-#    file, e.g., PASSWORD_PLAIN='my long passphrase'
-# 2. When you run speedport-w724v-external-ip-address for the first time after
-#    setting this, the program will calculate the MD5 hash sum of the specified
-#    password, and it will replace it in this file. Basically, it will replace:
-#        PASSWORD_PLAIN='my long passphrase'
-#    by:
-#        PASSWORD_MD5='2465a212324cc5b9f2e457fae0ed0a99'
-#    NOTICE:
-#    In order to perform this one-time change, the program needs to be able to
-#    write to this file, which probably means that it will need to run as root
-#    once after each device password change.
-#
-# Of course, you can specify directly the device password in its MD5 hash sum,
-# but then you just need to set the PASSWORD_MD5 directly.
+# Models and firmware tested:
+#   - Type C: 09011603.00.009
+# The password is required to retrieve the current external IPv4 and IPv6
+# addresses of the router.
 #
 # SECURITY NOTICE:
-# The choice of MD5 to hash the password was dictated by the router
-# authentication Web API. MD5 is far from perfect, but it is still better than
-# plain text.
+# The plaintext storage of the password was dictated by the router
+# authentication Web API. You should take all appropriate action to
+# prevent any unauthorized access to this file.
 #
 
 #PASSWORD_PLAIN='my long passphrase'

--- a/speedport-w724v-external-ip-address
+++ b/speedport-w724v-external-ip-address
@@ -5,68 +5,67 @@ CONF_FILE="/etc/speedport_w724v/device_password.conf"
 # Load configuration file
 
 if [ -f "$CONF_FILE" ]; then
-	source "$CONF_FILE"
+    source "$CONF_FILE"
 else
-	>&2 echo "Error: Configuration file '$CONF_FILE' not found."
-	exit 1
+    >&2 echo "Error: Configuration file '$CONF_FILE' not found."
+    exit 1
 fi
 
 # Check for device password
 
-if [ -z "$PASSWORD_MD5" ]; then
-	if [ -z "$PASSWORD_PLAIN" ]; then
-		>&2 echo "Error: Configuration file '$CONF_FILE' must specify a device password."
-		exit 1
-	else
-		>&2 echo "Warning: Device password specified in plain text. It will be replaced by its MD5 hash sum."
-		PASSWORD_MD5=`printf "$PASSWORD_PLAIN" | md5sum | cut -d ' ' -f 1`
-		PASSWORD_PLAIN=""
-		
-		if ! sed -i "s|^PASSWORD_PLAIN=.*\$|PASSWORD_MD5='$PASSWORD_MD5'|g" "$CONF_FILE" ; then
-			>&2 echo "Error: Could not write to configuration file '$CONF_FILE'."
-			exit 1
-		fi
-	fi
-elif [ -n "$PASSWORD_PLAIN" ]; then
-	>&2 echo "Warning: Device password specified in plain text. It will be deleted."
-	if ! sed -i 's|^PASSWORD_PLAIN=.*$||g' "$CONF_FILE" ; then
-		>&2 echo "Error: Could not write to configuration file '$CONF_FILE'."
-		exit 1
-	fi
+if [ -z "$PASSWORD_PLAIN" ]; then
+    >&2 echo "Error: Configuration file '$CONF_FILE' must specify a device password."
+    exit 1
 fi
 
-# Talk to the router
-
-SESSION_COOKIE="/tmp/speedport_ip_session_cookie_$$.txt"
-JSON_FILE="/tmp/speedport_ip_data_$$.json"
-AUTH_URL='http://speedport.ip/data/Login.json'
-INETIP_URL='http://speedport.ip/data/INetIP.json'
-
-rm "$SESSION_COOKIE" "$JSON_FILE" 2>/dev/null
-
-curl --silent --cookie-jar "$SESSION_COOKIE" --data "password=$PASSWORD_MD5&password_shadowed=$PASSWORD_MD5&showpw=0" "$AUTH_URL" > "$JSON_FILE"
-
-# The router JSON response is sometimes not well formed, so we need to fix known
+# Note: The router JSON response is sometimes not well formed, so we need to fix known
 # bad formatting before feeding the JSON data to jq.
-LOGIN_STATE=`cat "$JSON_FILE" | tr -d '\r\n' | sed 's|}[ \n\r]*,[ \n\r]*\]|}]|g' | jq '.[] | select(.varid == "loginstate").varvalue' | tr -d '"'`
 
-if [ "$LOGIN_STATE" -ne 1 ]; then
-	rm "$SESSION_COOKIE" "$JSON_FILE" 2>/dev/null
-	>&2 echo "Error: Login failed."
-	exit 1
-fi
+# Step 1: Login
 
-curl --silent --cookie "$SESSION_COOKIE" "$INETIP_URL" > "$JSON_FILE"
+LOGIN_HTTP=$(curl 'http://speedport.ip/data/Login.json' \
+		  --request POST \
+		  --header "Accept-Language: en" \
+		  --data "password=${PASSWORD_PLAIN}&showpw=0&csrf_token=sercomm_csrf_token" \
+		  --silent --verbose 2>&1)
+LOGIN_STATUS=$(echo -n "${LOGIN_HTTP}" \
+		      | grep -o '\[ { .*$' \
+		      | tr -d '\r\n' | sed 's|}[ \n\r]*,[ \n\r]*\]|}]|g' \
+		      | jq '.[] | select(.varid == "login").varvalue' \
+		      | tr -d '"')
+SESSION_ID=$(echo -n "${LOGIN_HTTP}" \
+		    | grep -oP 'session_id=\K[0-9a-fA-F]*')
 
-# Here is our external IP
-PUBLIC_IPV4=`cat "$JSON_FILE" | tr -d '\r\n' | sed 's|}[ \n\r]*,[ \n\r]*\]|}]|g' | jq '.[] | select(.varid == "public_ip_v4").varvalue' | tr -d '"'`
+# Step 2: Get CSRF Token
 
-# Clean up
+CSRF_TOKEN=$(curl 'http://speedport.ip/html/content/overview/index.html' \
+		  --request GET \
+		  --header 'Accept-Language: en' \
+		  --header 'Referer: http://speedport.ip/html/login/index.html' \
+		  --header 'Cookie: session_id='"${SESSION_ID}" \
+		  --silent \
+		    | grep -oP "csrf_token[ ]*=[ ]*[\'\"]\K[a-zA-Z0-9]*")
 
-curl --silent --cookie "$SESSION_COOKIE" --data 'logout=byby' "$AUTH_URL" > /dev/null
+# Step 3: Get IP
 
-rm "$SESSION_COOKIE" "$JSON_FILE"
+INET_JSON=$(curl 'http://speedport.ip/data/INetIP.json?_time='$(date +%s)'&csrf_token='"${CSRF_TOKEN}" \
+		 --request GET \
+		 --header 'Accept-Language: en' \
+		 --header 'Referer: http://speedport.ip/html/content/internet/connection.html' \
+		 --header 'Cookie: session_id='"${SESSION_ID}" \
+		 --silent \
+		   | tr -d '\r\n' | sed 's|}[ \n\r]*,[ \n\r]*\]|}]|g')
+PUBLIC_IPV4=$(echo -n "${INET_JSON}" | jq '.[] | select(.varid == "public_ip_v4").varvalue' | tr -d '"')
+PUBLIC_IPV6=$(echo -n "${INET_JSON}" | jq '.[] | select(.varid == "public_ip_v6").varvalue' | tr -d '"')
 
-# Done
+# Step 4: Logout
 
-echo "$PUBLIC_IPV4"
+curl 'http://speedport.ip/data/Login.json' \
+     --request POST \
+     --header "Accept-Language: en" \
+     --header 'Cookie: session_id='"${SESSION_ID}" \
+     --data 'logout=byby&csrf_token='"${CSRF_TOKEN}" \
+     --silent 1>/dev/null 2>&1
+
+# Step 5: Print public IPv4 and IPv6
+echo -ne "${PUBLIC_IPV4}\n${PUBLIC_IPV6}\n"


### PR DESCRIPTION
Original version will not work with the newest Speedport W724V Type C - Firmware 09011603.00.009, as that FW seems to require csrf tokens and plaintext passwords.
